### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   label-sync:
     name: Label Sync
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/arpansee/homeops/security/code-scanning/1](https://github.com/arpansee/homeops/security/code-scanning/1)

To address the issue, add a `permissions` block to scope the GITHUB_TOKEN's powers to the minimum necessary for synchronizing repository labels. The safest and simplest way is to add `permissions` inside the job definition for clarity and minimum privilege. For label sync, the required permission is typically `issues: write`, as labels are part of issue management; however, if the workflow also needs to interact with pull requests or commits, relevant permissions would need to be included. Based on the provided steps, only label syncing is performed, so `issues: write` and perhaps `contents: read` (for workflow/checkout) suffice.

**What to do:**  
- Edit the `.github/workflows/label-sync.yaml` file.
- Insert a `permissions:` block at line 13 (inside the `label-sync` job).
- Use the following minimal permissions:
  ```yaml
  permissions:
    contents: read
    issues: write
  ```
- This will cover the needs of label sync actions without granting excessive repository access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
